### PR TITLE
fix: config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,5 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']
 remappings = ['ds-test/=lib/ds-test/src/']
-
-# See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/src/test/ExcessivelySafeCall.t.sol
+++ b/src/test/ExcessivelySafeCall.t.sol
@@ -200,23 +200,23 @@ contract CallTarget {
         called = msg.value;
     }
 
-    function retBytes(uint256 _bytes) public view {
+    function retBytes(uint256 _bytes) public pure {
         assembly {
             return(0, _bytes)
         }
     }
 
-    function revBytes(uint256 _bytes) public view {
+    function revBytes(uint256 _bytes) public pure {
         assembly {
             revert(0, _bytes)
         }
     }
 
-    function badRet() external returns (bytes memory) {
+    function badRet() external pure returns (bytes memory) {
         retBytes(1_000_000);
     }
 
-    function badRev() external{
+    function badRev() external pure {
         revBytes(1_000_000);
     }
 }


### PR DESCRIPTION
Updates the `foundry.toml` file to use new foundry config syntax. Eventually foundry will not support the old syntax, this does require a relatively newer version of foundry to still build.

Also fix compiler warnings in the tests